### PR TITLE
Add activated/deactivated callbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,10 +94,11 @@ d3.select('#chart_placeholder')
     <p>DependencyWheel follows the <a href="http://bost.ocks.org/mike/chart/">d3.js reusable charts</a> pattern to let you customize the chart at will:</p>
 <pre>
 var chart = d3.chart.dependencyWheel()
-  .width(700)            // also used for height, since the wheel is in a a square
-  .margin(150)           // used to display package names
-  .padding(.02)          // separating groups in the wheel
-  .onHover(doSomething); // called with the packageName index on hover
+  .width(700)               // also used for height, since the wheel is in a a square
+  .margin(150)              // used to display package names
+  .padding(.02)             // separating groups in the wheel
+  .onActivated(showInfo);   // called with the packageName index on mouseover
+  .onDeactivated(hideInfo); // called with the packageName index on mouseout
 </pre>
 
     <h2>Sharing your DependencyWheels</h2>

--- a/js/d3.dependencyWheel.js
+++ b/js/d3.dependencyWheel.js
@@ -36,7 +36,8 @@ d3.chart.dependencyWheel = function(options) {
   var width = 700;
   var margin = 150;
   var padding = 0.02;
-  var onHover = null;
+  var onActivated = null;
+  var onDeactivated = null;
 
   function chart(selection) {
     selection.each(function(data) {
@@ -100,8 +101,22 @@ d3.chart.dependencyWheel = function(options) {
               })
               .transition()
                 .style("opacity", opacity);
-          if (typeof onHover === 'function') {
-            onHover(i);
+        };
+      };
+
+      var activate = function (fader) {
+        return function (g, i) {
+          fader(g, i);
+          if (typeof onActivated === 'function') {
+            onActivated(i);
+          }
+        };
+      };
+      var deactivate = function (fader) {
+        return function (g, i) {
+          fader(g, i);
+          if (typeof onDeactivated === 'function') {
+            onDeactivated(i);
           }
         };
       };
@@ -124,8 +139,8 @@ d3.chart.dependencyWheel = function(options) {
         .style("stroke", fill)
         .attr("d", arc)
         .style("cursor", "pointer")
-        .on("mouseover", fade(0.1))
-        .on("mouseout", fade(1));
+        .on("mouseover", activate(fade(0.1)))
+        .on("mouseout", deactivate(fade(1)));
 
       g.append("svg:text")
         .each(function(d) { d.angle = (d.startAngle + d.endAngle) / 2; })
@@ -138,8 +153,8 @@ d3.chart.dependencyWheel = function(options) {
         })
         .style("cursor", "pointer")
         .text(function(d) { return packageNames[d.index]; })
-        .on("mouseover", fade(0.1))
-        .on("mouseout", fade(1));
+        .on("mouseover", activate(fade(0.1)))
+        .on("mouseout", deactivate(fade(1)));
 
       gEnter.selectAll("path.chord")
           .data(chord.chords)
@@ -173,9 +188,15 @@ d3.chart.dependencyWheel = function(options) {
     return chart;
   };
 
-  chart.onHover = function(callback) {
+  chart.onActivated = function(callback) {
     if (!arguments.length) return callback;
-    onHover = callback;
+    onActivated = callback;
+    return chart;
+  };
+
+  chart.onDeactivated = function(callback) {
+    if (!arguments.length) return callback;
+    onDeactivated = callback;
     return chart;
   };
 


### PR DESCRIPTION
This introduces two new options, letting the user of DependencyWheel pass callbacks that gets called with the _packageName_ index on "activated" and "deactivated" events (when the user hovers and things fade in/out).

If anyone can come up with a better naming than _activated/deactivated_, that would probably be nice.
