### PR TITLE
Updating Example page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Dependency Wheel
 
 This experiment visualizes package dependencies using an interactive disc. Each disc section represents a dependency, and links between arcs materialize these dependencies. All rendering is done client-side, in JavaScript. Built with <a href="https://github.com/mbostock/d3">d3.js</a>, published with the MIT open-source license.
 
-Interact with DependencyWheels, see examples, and build your own at [http://fzaninotto.github.com/DependencyWheel](http://fzaninotto.github.com/DependencyWheel).
+Interact with DependencyWheels, see examples, and build your own at [http://www.redotheweb.com/DependencyWheel/](http://www.redotheweb.com/DependencyWheel/).
 
 ![The Dependency Wheel of the sylius/sylius project](http://redotheweb.com/DependencyWheel/img/dependency_chord.gif)


### PR DESCRIPTION
http://fzaninotto.github.com/DependencyWheel is 404 There isn't a GitHub Pages site here.
instead  example available at http://www.redotheweb.com/DependencyWheel/